### PR TITLE
db:seed does not longer try to create invalid user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
@@ -8,5 +9,10 @@
 puts 'EMPTY THE MONGODB DATABASE'
 Mongoid.master.collections.reject { |c| c.name =~ /^system/}.each(&:drop)
 puts 'SETTING UP DEFAULT USER LOGIN'
-user = User.create! :name => 'admin', :email => 'user@test.com', :password => 'please', :password_confirmation => 'please', :admin => true
+user = User.create! :name => 'admin', :email => 'user@test.com', :password => 'please',
+                    :password_confirmation => 'please', :admin => true,
+                    :first_name => 'Max', :last_name => 'Mustermann',
+                    :organization => 'Universität Paderborn',
+                    :faculty => 'Fakultät für Wirtschaftswissenschaften',
+                    :chair => 'PINGO'
 puts 'user@test.com created (Password: please): ' << user.email


### PR DESCRIPTION
`rake db:seed` bricht ansonsten mit folgender Meldung ab:

```
[heiko@hades ~/Downloads/PINGOWebApp ±master]$ bundle exec rake db:seed
EMPTY THE MONGODB DATABASE
SETTING UP DEFAULT USER LOGIN
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
rake aborted!
Validation failed - First name can't be blank, Last name can't be blank, Chair can't be blank, Faculty can't be blank, Organization can't be blank.
/Users/heiko/Downloads/PINGOWebApp/db/seeds.rb:11:in `<top (required)>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```
