### PR TITLE
auto-generate secret_token if no token exists.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log/*.log
 tmp/
 .sass-cache/
 coverage
+.secret

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,23 @@
 # Be sure to restart your server when you modify this file.
 
+require 'securerandom'
+
 # Your secret key for verifying the integrity of signed cookies.
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Eclickr::Application.config.secret_token = ''
+
+def find_secure_token
+  token_file = Rails.root.join('.secret')
+  if File.exist? token_file
+    # Use the existing token.
+    File.read(token_file).chomp
+  else
+    # Generate a new token of 64 random hexadecimal characters and store it in token_file.
+    token = SecureRandom.hex(64)
+    File.write(token_file, token)
+    token
+  end
+end
+
+Eclickr::Application.config.secret_token = find_secure_token


### PR DESCRIPTION
Das vereinfacht das Deployment, da die Rails-App selber ein Token generiert, wenn es noch keins gibt.
Ebenso besteht nun nicht mehr die Gefahr, dass man aus Versehen das Token in Git eincheckt. 

Ich habe mich dabei an die Umsetzung von GitLab orientiert: https://github.com/gitlabhq/gitlabhq/blob/e444c7f6babe956ef22a775b8ec197d58765b6a0/config/initializers/secret_token.rb

Bei bestehenden Installationen müsste der Token einmalig vor dem Updaten in die Datei `.secret` kopiert werden.
