### PR TITLE
Survey result export not working properly when using commata

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -225,7 +225,7 @@ class EventsController < ApplicationController
     check_access
     return if performed?
 
-    csv_data = CSV.generate col_sep: "\t"  do |csv|
+    csv_data = CSV.generate col_sep: "\t", quote_char: '"', force_quotes: true  do |csv|
       # header row
       csv << ['Survey ID', 'Question', 'Question Type', 'Question Options', 'Voter ID', 'Survey Start', 'Survey End', 'Answer']
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -257,17 +257,6 @@ class EventsController < ApplicationController
     send_data csv_data, :type => 'text/csv; charset=utf-8; header=present', :filename => 'PINGO_surveys_'+@event.token+'_'+Time.current.to_s.tr(" ", "_")+'.csv'
   end
 
-    # GET /events/:id/export_json
-  def export_json
-    @event ||= Event.find_by_id_or_token(params[:id])
-
-    check_access
-    return if performed?
-
-    #TODO: JSON-export
-
-  end
-
   protected
   def event_params
     params.require(:event).permit(:name, :description, :mathjax, :collaborators_form, :custom_locale)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -257,6 +257,17 @@ class EventsController < ApplicationController
     send_data csv_data, :type => 'text/csv; charset=utf-8; header=present', :filename => 'PINGO_surveys_'+@event.token+'_'+Time.current.to_s.tr(" ", "_")+'.csv'
   end
 
+    # GET /events/:id/export_json
+  def export_json
+    @event ||= Event.find_by_id_or_token(params[:id])
+
+    check_access
+    return if performed?
+
+    #TODO: JSON-export
+
+  end
+
   protected
   def event_params
     params.require(:event).permit(:name, :description, :mathjax, :collaborators_form, :custom_locale)

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -6,11 +6,18 @@ class SurveysController < ApplicationController
   # GET /events/:event_id/surveys
   # GET /events/:event_id/surveys.json
   def index
-    event = Event.find_by_id_or_token(params[:event_id])
+    @event = Event.find_by_id_or_token(params[:event_id])
+    check_access
+    return if performed?
+    
+    @surveys = @event.surveys.display_fields.desc(:created_at)
 
     respond_to do |format|
-      format.html { render partial: "events/surveys_table", locals: {event: event} }
-      format.json { render json: @surveys }
+      format.html { render partial: "events/surveys_table", locals: {event: @event} }
+      format.json { send_data @surveys.to_json, 
+                              :type => 'json; charset=utf-8; header=present', 
+                              :filename => 'PINGO_surveys_'+@event.token+'_'+Time.current.to_s.tr(" ", "_")+'.json' 
+                  }
     end
   end
 

--- a/app/services/choice_survey.rb
+++ b/app/services/choice_survey.rb
@@ -99,7 +99,7 @@ class ChoiceSurvey < GenericSurvey
 
   # returns options concatenated as string
   def options_s
-    self.options.map{ |option| "'#{option.name}'" }.join(", ")
+    self.options.map(&:name).to_csv(row_sep: "")
   end
 
   # VIEW OPTIONS

--- a/app/services/choice_survey.rb
+++ b/app/services/choice_survey.rb
@@ -99,7 +99,7 @@ class ChoiceSurvey < GenericSurvey
 
   # returns options concatenated as string
   def options_s
-    self.options.map(&:name).join(", ")
+    self.options.map{ |option| "'#{option.name}'" }.join(", ")
   end
 
   # VIEW OPTIONS

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -89,7 +89,7 @@
 			<%= link_to event_path(@event)+"/export", class: 'btn pull-right' do %>
 			  <i class="icon-ok icon-file"> </i> <%= t('events.show.export_results') %>
 			<% end %>
-			<%= link_to event_path(@event)+"/export_json", class: 'btn pull-right' do %>
+			<%= link_to event_path(@event)+"/surveys.json", class: 'btn pull-right' do %>
 			  <i class="icon-ok icon-file"> </i> <%= t('events.show.export_results_json') %>
 			<% end %>
 		<% else %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -89,6 +89,9 @@
 			<%= link_to event_path(@event)+"/export", class: 'btn pull-right' do %>
 			  <i class="icon-ok icon-file"> </i> <%= t('events.show.export_results') %>
 			<% end %>
+			<%= link_to event_path(@event)+"/export_json", class: 'btn pull-right' do %>
+			  <i class="icon-ok icon-file"> </i> <%= t('events.show.export_results_json') %>
+			<% end %>
 		<% else %>
 			<p id="event-survey-no-surveys"><%= t ".no_surveys" %><br/>
 			</p>

--- a/config/locales/views/events.de.yml
+++ b/config/locales/views/events.de.yml
@@ -17,6 +17,7 @@ de:
             compare_votings: Abstimmverhalten vergleichen
             show_questions: Frage aus Katalog starten
             export_results: Antworten exportieren
+            export_results_json: JSON exportieren
         questions_table:
             all_tags: Alle Tags
         index:

--- a/config/locales/views/events.en.yml
+++ b/config/locales/views/events.en.yml
@@ -16,6 +16,8 @@ en:
             connected: currently connected
             compare_votings: compare voting behaviour
             show_questions: Start question from list
+            export_results: Export results
+            export_results_json: Export JSON
         questions_table:
             all_tags: All Tags
         index:


### PR DESCRIPTION
Whenever I try to export a surveys result (in version 2.3 and 3.0) the question options can't be separated properly.

As an example I have 3 possible answers : 

1. Yes, it is
2. No, it isn't
3. I don't know

These questions are represented inside the CSV file like the following : 

```
Yes, it is, No, it isn't, I don't know
```

This would lead to 5 possible answers when using a comma as the parsers delimiter.

I tried to fix this behavior by changing the string the CSV parser gets inside `events_controller.rb`.

Now the questions look like this inside the CSV file : 

```
"""Yes, it is"",""No, it isn't"",""I don't know"""
```

In Java I can now use this column for parsing the question options like this : 

```Java
CSVParser parser = CSVParser.parse(csvFile, Charset.defaultCharset(), CSVFormat.TDF);
    for(CSVRecord record : parser){
        CSVParser optionParser = CSVParser.parse(record.get(3), CSVFormat.DEFAULT);

        for(String option : optionParser.getRecords().get(0)){
            System.out.println(option);
        }
    }
```