### PR TITLE
tried to fix success message escaping (fix #26)

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -258,7 +258,7 @@ class SurveysController < ApplicationController
             end
           else
             if params[:option].respond_to? :each
-              voted_for = "<br>- " + params[:option].reject {|o| o.blank? }.join("<br>- ") + "<br>"
+              voted_for = " " + params[:option].reject {|o| o.blank? }.join(", ")
             else
               voted_for = params[:option]
             end


### PR DESCRIPTION
Trying to fix error #26 

html escaping makes sense here, as the option names are printed
-> either escaping option names or just removing html styling from such small error message
=> removed html styling